### PR TITLE
list support format json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,13 @@ hfm list
 127.0.0.1 localhost
 255.255.255.255 broadcasthost
 ::1 localhost
+
+hfm list --format json
+
+[{"Hosts":["localhost"],"IP":"127.0.0.1","Line":8,"Raw":"127.0.0.1\tlocalhost"},{"Hosts":["broadcasthost"],"IP":"255.255.255.255","Line":9,"Raw":"255.255.255.255\tbroadcasthost"},{"Hosts":["localhost"],"IP":"::1","Line":10,"Raw":"::1 localhost "}]
+```
+
+
 ```
 
 #### Add

--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ hfm list --format json
 #### Add
 
 ```sh
-hfm add 0.0.0.0 hoge.com
+hfm add 0.0.0.0 hoge.com (--format json)
 
 Added 0.0.0.0 hoge.com
 ```
@@ -38,7 +38,7 @@ Added 0.0.0.0 hoge.com
 #### Update
 
 ```sh
-hfm update 0.0.0.0 hoge.com huga.com
+hfm update 0.0.0.0 hoge.com huga.com (--format json)
 
 Updated 0.0.0.0 hoge.com huga.com
 ```
@@ -46,7 +46,7 @@ Updated 0.0.0.0 hoge.com huga.com
 #### Remove
 
 ```sh
-hfm remove 0.0.0.0
+hfm remove 0.0.0.0 (--format json)
 
 Removed 0.0.0.0 hoge.com huga.com
 ```

--- a/cmd/hfm/main.go
+++ b/cmd/hfm/main.go
@@ -46,8 +46,13 @@ func main() {
 			Name:    "add",
 			Aliases: []string{"a"},
 			Usage:   "add a hosts record to hosts file",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "format, f",
+					Usage: "output format type",
+				},
+			},
 			Action: func(c *cli.Context) error {
-
 				ip := c.Args().Get(0)
 				hosts := c.Args()[1:]
 				record, err := hfm.Add(ip, hosts...)
@@ -56,8 +61,15 @@ func main() {
 					return err
 				}
 
-				cyan := chalk.Cyan.NewStyle()
-				fmt.Printf("%sAdded %s %s\n", cyan, record.IP, strings.Join(record.Hosts, " "))
+				format := c.String("format")
+
+				if format == "json" {
+					json := ToJSON(record)
+					fmt.Println(json)
+				} else {
+					cyan := chalk.Cyan.NewStyle()
+					fmt.Printf("%sAdded %s %s\n", cyan, record.IP, strings.Join(record.Hosts, " "))
+				}
 
 				return nil
 			},
@@ -66,8 +78,13 @@ func main() {
 			Name:    "remove",
 			Aliases: []string{"r"},
 			Usage:   "remove a hosts record to hosts file",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "format, f",
+					Usage: "output format type",
+				},
+			},
 			Action: func(c *cli.Context) error {
-
 				ip := c.Args().Get(0)
 				record, err := hfm.Remove(ip)
 
@@ -75,8 +92,16 @@ func main() {
 					return err
 				}
 
-				red := chalk.Red.NewStyle()
-				fmt.Printf("%sRemoved %s %s\n", red, record.IP, strings.Join(record.Hosts, " "))
+				format := c.String("format")
+
+				if format == "json" {
+					json := ToJSON(record)
+					fmt.Println(json)
+				} else {
+					red := chalk.Red.NewStyle()
+					fmt.Printf("%sRemoved %s %s\n", red, record.IP, strings.Join(record.Hosts, " "))
+				}
+
 				return nil
 			},
 		},
@@ -84,6 +109,12 @@ func main() {
 			Name:    "update",
 			Aliases: []string{"u"},
 			Usage:   "update a hosts record to hosts file",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "format, f",
+					Usage: "output format type",
+				},
+			},
 			Action: func(c *cli.Context) error {
 
 				ip := c.Args().Get(0)
@@ -94,8 +125,16 @@ func main() {
 					return err
 				}
 
-				green := chalk.Green.NewStyle()
-				fmt.Printf("%sUpdated %s %s\n", green, record.IP, strings.Join(record.Hosts, " "))
+				format := c.String("format")
+
+				if format == "json" {
+					json := ToJSON(record)
+					fmt.Println(json)
+				} else {
+					green := chalk.Green.NewStyle()
+					fmt.Printf("%sUpdated %s %s\n", green, record.IP, strings.Join(record.Hosts, " "))
+				}
+
 				return nil
 			},
 		},
@@ -119,17 +158,23 @@ func main() {
 				format := c.String("format")
 
 				if format == "json" {
-					b, _ := json.Marshal(records)
-					fmt.Println(string(b))
+					json := ToJSON(records)
+					fmt.Println(json)
 				} else {
 					for _, r := range records {
 						fmt.Printf("%s %s\n", r.IP, strings.Join(r.Hosts, " "))
 					}
 				}
+
 				return nil
 			},
 		},
 	}
 
 	app.Run(os.Args)
+}
+
+func ToJSON(records interface{}) string {
+	b, _ := json.Marshal(records)
+	return string(b)
 }

--- a/cmd/hfm/main.go
+++ b/cmd/hfm/main.go
@@ -37,9 +37,9 @@ func main() {
 	}
 	app.Usage = "hosts file management"
 	app.UsageText = `
-	add (a)    - hfm add <IP> <HOSTS...>
-	remove (r) - hfm remove <IP>
-	update (u) - hfm update <IP> <HOSTS...>
+	add (a)    - hfm add <IP> <HOSTS...> [--format json]
+	remove (r) - hfm remove <IP> [--format json]
+	update (u) - hfm update <IP> <HOSTS...> [--format jsos 
 	list (l)   - hfm list [--format json] `
 	app.Commands = []cli.Command{
 		{

--- a/cmd/hfm/main.go
+++ b/cmd/hfm/main.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"encoding/json"
+
+	"github.com/kazu69/hosts_file_manager"
 	"github.com/ttacon/chalk"
 	"github.com/urfave/cli"
-	"github.com/kazu69/hosts_file_manager"
 )
 
 var (
@@ -38,7 +40,7 @@ func main() {
 	add (a)    - hfm add <IP> <HOSTS...>
 	remove (r) - hfm remove <IP>
 	update (u) - hfm update <IP> <HOSTS...>
-	list (l)   - hfm list`
+	list (l)   - hfm list [--format json] `
 	app.Commands = []cli.Command{
 		{
 			Name:    "add",
@@ -101,6 +103,12 @@ func main() {
 			Name:    "list",
 			Aliases: []string{"l"},
 			Usage:   "lits hosts records to hosts file",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "format, f",
+					Usage: "output format type",
+				},
+			},
 			Action: func(c *cli.Context) error {
 				records := hfm.List()
 
@@ -108,10 +116,16 @@ func main() {
 					return err
 				}
 
-				for _, r := range records {
-					fmt.Printf("%s %s\n", r.IP, strings.Join(r.Hosts, " "))
-				}
+				format := c.String("format")
 
+				if format == "json" {
+					b, _ := json.Marshal(records)
+					fmt.Println(string(b))
+				} else {
+					for _, r := range records {
+						fmt.Printf("%s %s\n", r.IP, strings.Join(r.Hosts, " "))
+					}
+				}
 				return nil
 			},
 		},


### PR DESCRIPTION
In this pull request, add `json` as an option as the output format of` list`.

By doing the following you can output with json.


```sh
hfm list --format json | jq .
[
  {
    "Hosts": [
      "localhost"
    ],
    "IP": "127.0.0.1",
    "Line": 8,
    "Raw": "127.0.0.1\tlocalhost"
  },
  {
    "Hosts": [
      "broadcasthost"
    ],
    "IP": "255.255.255.255",
    "Line": 9,
    "Raw": "255.255.255.255\tbroadcasthost"
  },
  {
    "Hosts": [
      "localhost"
    ],
    "IP": "::1",
    "Line": 10,
    "Raw": "::1             localhost "
  }
]
```

